### PR TITLE
making "output" public to allow access according to examples

### DIFF
--- a/Sources/ISSoundAdditions/Sound.swift
+++ b/Sources/ISSoundAdditions/Sound.swift
@@ -13,5 +13,5 @@
 /// You can use the shared instance to change the output volume as well as
 /// mute and unmute.
 public enum Sound {
-  static let output = SoundOutputManager()
+  public static let output = SoundOutputManager()
 }


### PR DESCRIPTION
Allowing access to `output` so that `Sound` can be used as the examples specify.